### PR TITLE
UCX: Remove EPs from storages in error handling callback

### DIFF
--- a/src/ucx_van.h
+++ b/src/ucx_van.h
@@ -239,6 +239,7 @@ public:
       auto server_check = [ep](const auto &mo) {return mo->ep == ep;};
       auto server_it    = std::find_if(server_eps_.begin(), server_eps_.end(),
                                        server_check);
+      assert(server_it != server_eps_.end());
       server_eps_.erase(server_it);
       UCX_LOGE(1, "ep close errh: " << ep);
     }

--- a/src/ucx_van.h
+++ b/src/ucx_van.h
@@ -219,21 +219,27 @@ public:
   void ErrorHandler(ucp_ep_h ep)
   {
     mu_.lock();
-    auto check  = [ep](const auto &mo) {return mo.second->ep == ep;};
-    auto result = std::find_if(client_eps_.begin(), client_eps_.end(), check);
-    if (result != client_eps_.end()) {
-        UCXEp *uep = result->second.get();
-        if (!uep->connected) {
-            uep->ep = nullptr;
-            std::this_thread::sleep_for(std::chrono::milliseconds(reconnect_tmo_));
-            Create(uep);
-            UCX_LOGE(1, "ep close errh: " << ep << "|" << result->first
-                     << " Reconnect, close reqs " << close_ep_reqs_.size());
-        } else {
-            UCX_LOGE(1, "ep close errh: " << ep << "|" << result->first
-                     << " peer failure");
-        }
+    auto client_check = [ep](const auto &mo) {return mo.second->ep == ep;};
+    auto client_it    = std::find_if(client_eps_.begin(), client_eps_.end(),
+                                     client_check);
+    if (client_it != client_eps_.end()) {
+      UCXEp *uep = client_it->second.get();
+      if (!uep->connected) {
+        uep->ep = nullptr;
+        std::this_thread::sleep_for(std::chrono::milliseconds(reconnect_tmo_));
+        Create(uep);
+        UCX_LOGE(1, "ep close errh: " << ep << "|" << client_it->first
+                 << " Reconnect, close reqs " << close_ep_reqs_.size());
+      } else {
+        UCX_LOGE(1, "ep close errh: " << ep << "|" << client_it->first
+                 << " peer failure");
+        client_eps_.erase(client_it);
+      }
     } else {
+      auto server_check = [ep](const auto &mo) {return mo->ep == ep;};
+      auto server_it    = std::find_if(server_eps_.begin(), server_eps_.end(),
+                                       server_check);
+      server_eps_.erase(server_it);
       UCX_LOGE(1, "ep close errh: " << ep);
     }
     mu_.unlock();


### PR DESCRIPTION
If UCP error handling callback was called, we have to do the following actions to avoid double close of the same UCP EP:
1) check hash of client EPs
-- if the EP exists in this map, and it is not connected, reconnect to the peer creating the new UCP EP
-- if the EP exists in this map, and it's connected, remove the EP form the hash
2) if EP was not found in hash of client EPs, check hash of server EPs
-- EP has to be here, remove the EP form the hash
3) close the failed UCP EP


otherwise, it is failed with undefined behavior (UCP EP `0x7f6a087de070` was closed twice in this test):
```
...
[21:02:18] src/./ucx_van.h:247: W[9] ERRH ep 0x7f6a087de070: Connection reset by remote peer
[21:02:18] src/./ucx_van.h:237: W ep close errh: 0x7f6a087de070
[21:02:18] src/./ucx_van.h:216: W close ep 0x7f6a087de070 with req 0
...
[21:02:18] src/./ucx_van.h:181: W ep close in cleanup: 0x7f6a087de070
[jazz12:74329:1:74329]      ucp_ep.c:963  Assertion `(&worker->async)->signal.tid == ucs_get_tid()' failed
/labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c: [ ucp_ep_close_nbx() ]
      ...
      960     }
      961
      962     UCS_ASYNC_BLOCK(&worker->async);
==>   963
      964     ep->flags |= UCP_EP_FLAG_CLOSED;
      965     uct_flags  = force ? UCT_FLUSH_FLAG_CANCEL : UCT_FLUSH_FLAG_LOCAL;
      966     request    = ucp_ep_flush_internal(ep, uct_flags, 0,
==== backtrace (tid:  74329) ====
 0 0x0000000000030623 ucp_ep_close_nbx()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:963
 1 0x0000000000030518 ucp_ep_close_nb()  /labhome/dmitrygla/work_auto/ucx/src/ucp/core/ucp_ep.c:946
 2 0x000000000043a00d ps::UCXEndpointsPool::CloseEp()  /labhome/dmitrygla/work_auto/bd-ps-lite/src/./ucx_van.h:209
 3 0x000000000043acce ps::UCXEndpointsPool::Cleanup()  /labhome/dmitrygla/work_auto/bd-ps-lite/src/./ucx_van.h:182
 4 0x000000000043acce std::__detail::_Node_iterator<std::unique_ptr<ps::UCXEp, std::default_delete<ps::UCXEp> >, true, false>::operator++()  /hpc/local/oss/gcc-9.2.0/include/c++/9.2.0/bits/hashtable_policy.h:354
 5 0x000000000043acce ps::UCXEndpointsPool::Cleanup()  /labhome/dmitrygla/work_auto/bd-ps-lite/src/./ucx_van.h:180
 6 0x000000000043b0c1 ps::UCXVan::Stop()  /labhome/dmitrygla/work_auto/bd-ps-lite/src/./ucx_van.h:393
 7 0x0000000000420ba3 ps::Postoffice::Finalize()  /labhome/dmitrygla/work_auto/bd-ps-lite/src/postoffice.cc:97
 8 0x0000000000420ba3 std::unordered_map<int, std::unordered_map<int, ps::Customer*, std::hash<int>, std::equal_to<int>, std::allocator<std::pair<int const, ps::Customer*> > >, std::hash<int>, std::equal_to<int>, std::allocator<std::pair<int const, std::unordered_map<int, ps::Customer*, std::hash<int>, std::equal_to<int>, std::allocator<std::pair<int const, ps::Customer*> > > > > >::clear()  /hpc/local/oss/gcc-9.2.0/include/c++/9.2.0/bits/unordered_map.h:843
 9 0x0000000000420ba3 ps::Postoffice::Finalize()  /labhome/dmitrygla/work_auto/bd-ps-lite/src/postoffice.cc:99
10 0x000000000040834d ps::Finalize()  /labhome/dmitrygla/work_auto/bd-ps-lite/./include/ps/ps.h:56
11 0x00000000000223d5 __libc_start_main()  ???:0
12 0x00000000004084b6 _start()  ???:0
=================================
```