### PR TITLE
ucx: protect w_pool_ with a lock

### DIFF
--- a/src/ucx_van.h
+++ b/src/ucx_van.h
@@ -473,6 +473,7 @@ class UCXVan : public Van {
 
     if (msg.meta.push && msg.meta.request) {
       // Save push data address for later pull
+      std::lock_guard<std::mutex> lock(w_pool_mtx_);
       w_pool_[msg.meta.key] = msg.data[1].data();
     }
 
@@ -561,6 +562,7 @@ class UCXVan : public Van {
   char *GetRxBuffer(uint64_t key, int node_id, size_t size, bool push) {
     if (!push) {
       // Must be receive for pulled data, get the address used for push
+      std::lock_guard<std::mutex> lock(w_pool_mtx_);
       auto addr = w_pool_.find(key);
       CHECK(addr != w_pool_.end());
       return addr->second;
@@ -803,6 +805,7 @@ class UCXVan : public Van {
   ThreadsafeQueue<UCXBuffer>                        recv_buffers_;
   UCXEndpointsPool                                  ep_pool_;
   std::unordered_map<Key, char*>                    w_pool_;
+  std::mutex                                        w_pool_mtx_;
   std::atomic<bool>                                 should_stop_;
   std::unordered_map<Key, MemAddresses>             rpool_;
   int                                               short_send_thresh_;


### PR DESCRIPTION
protect w_pool_ access with a lock to prevent race conditions.

Signed-off-by: Yulu Jia <yulu.jia@bytedance.com>