### PR TITLE
UCX: Fix server ep cleanup flow

### DIFF
--- a/src/ucx_van.h
+++ b/src/ucx_van.h
@@ -239,8 +239,10 @@ public:
       auto server_check = [ep](const auto &mo) {return mo->ep == ep;};
       auto server_it    = std::find_if(server_eps_.begin(), server_eps_.end(),
                                        server_check);
-      assert(server_it != server_eps_.end());
-      server_eps_.erase(server_it);
+      // ep may not be present in the set if ep id is not arrived yet (see AmRxNodeInfoReq)
+      if (server_it != server_eps_.end()) {
+        server_eps_.erase(server_it);
+      }
       UCX_LOGE(1, "ep close errh: " << ep);
     }
     mu_.unlock();


### PR DESCRIPTION
Remove incorrect assert, because ep may not receive peer ID yet when the connection fails/closed. In this case ep is not present in the set of server eps.