### PR TITLE
kv_app: fix compiler warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ all: ps test
 include make/deps.mk
 
 clean:
-	rm -rf build $(TEST) tests/*.d tests/*.dSYM
+	rm -rf build deps $(TEST) tests/*.d tests/*.dSYM
 
 lint:
 	python tests/lint.py ps all include/ps src

--- a/include/ps/kv_app.h
+++ b/include/ps/kv_app.h
@@ -596,11 +596,12 @@ void KVWorker<Val>::Send(int timestamp, bool push, int cmd, KVPairs<Val>& kvs) {
     auto& kvs = s.second;
     msg.meta.addr = reinterpret_cast<uint64_t>(kvs.vals.data());
     msg.meta.val_len = kvs.vals.size();
+
+    src_dev_type = kvs.vals.src_device_type_;
+    src_dev_id = kvs.vals.src_device_id_;
+    dst_dev_type = kvs.vals.dst_device_type_;
+    dst_dev_id = kvs.vals.dst_device_id_;
     if (!msg.meta.push) {
-      src_dev_type = kvs.vals.src_device_type_;
-      src_dev_id = kvs.vals.src_device_id_;
-      dst_dev_type = kvs.vals.dst_device_type_;
-      dst_dev_id = kvs.vals.dst_device_id_;
       kvs.vals.clear();
     }
     if (kvs.keys.size()) {


### PR DESCRIPTION
- initialize src_dev_type etc. so that the compiler won't complain.
- remove the deps directory when running make clean

Signed-off-by: Yulu Jia <yulu.jia@bytedance.com>