### PR TITLE
UCX: Fix TX,RX and progress threads race

### DIFF
--- a/src/ucx_van.h
+++ b/src/ucx_van.h
@@ -567,8 +567,13 @@ public:
     ucp_tag_recv_info_t info;
     int cnt = 0;
 
-    // Poll all underlying transports(IB, shm, tcp, etc)
+    // Poll all underlying transports(IB, shm, tcp, etc). Need to take a lock
+    // here to avoid interference with recv flow. Progress should not be run
+    // while RX thread just completed ucp_tag_recv_nb(), but has not initialized
+    // receive request yet (see PostRecvData).
+    rx_mu_.lock();
     cnt = ucp_worker_progress(worker_);
+    rx_mu_.unlock();
     if (cnt == 0) {
       return;
     }
@@ -598,12 +603,31 @@ public:
     int dst_dev_id = msg.meta.dst_dev_id;
     ucp_ep_h ep    = ep_pool_.Find(id, dst_dev_id);
     ucp_tag_t stag = MakeTag(my_node_->id, tag, msg.meta.key);
+    ucp_request_param_t send_param;
 
     UCX_LOGE(2, "Send to ep " << ep  << " (" << id << ", " << dst_dev_id <<")");
 
     if (ep == nullptr) return UCS_STATUS_PTR(UCS_ERR_NOT_CONNECTED);
 
-    return ucp_tag_send_nb(ep, buf, count, dt, stag, TxReqCompletedCb);
+    if (tag == ps::Tags::UCX_TAG_META) {
+        // Initialize completion callback for sending meta data to free the tx
+        // buffer. It is not needed for real data, because tx buffer is managed
+        // by PS-Lite.
+        send_param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK |
+                                  UCP_OP_ATTR_FIELD_USER_DATA;
+        send_param.cb.send      = TxReqCompletedCb;
+        send_param.user_data    = buf;
+    } else {
+        CHECK_EQ(tag,  ps::Tags::UCX_TAG_DATA);
+        send_param.op_attr_mask = 0ul;
+    }
+
+    ucs_status_ptr_t st = ucp_tag_send_nbx(ep, buf, count, stag, &send_param);
+    if (UCS_PTR_IS_PTR(st)) {
+        ucp_request_free(st);
+    }
+
+    return st;
   }
 
   void Cleanup() {
@@ -657,6 +681,7 @@ private:
                                               val_len, meta->push);
       ucp_tag_t tag   = MakeTag(meta_req->data.sender, Tags::UCX_TAG_DATA,
                                 meta->key);
+      rx_mu_.lock();
       UCXRequest *req = (UCXRequest*)ucp_tag_recv_nb(worker_, buf, val_len,
                                                      ucp_dt_make_contig(1), tag,
                                                      std::numeric_limits<uint64_t>::max(),
@@ -670,6 +695,7 @@ private:
         rx_pool_->Push(req->data);
         UCX_REQUEST_FREE(req);
       }
+      rx_mu_.unlock();
     }
     // if request is not completed in-place, it will be handled
     // in RxDataCompletedCb callback
@@ -679,12 +705,14 @@ private:
 
   UCXRequest* PostRecvMeta(ucp_tag_message_h msg, ucp_tag_recv_info_t *info) {
     char *rmeta     = new char[info->length];
+    rx_mu_.lock();
     UCXRequest *req = (UCXRequest*)ucp_tag_msg_recv_nb(worker_, rmeta, info->length,
                                                        ucp_dt_make_contig(1), msg,
                                                        RxMetaCompletedCb);
     req->ctx           = this;
     req->data.raw_meta = rmeta;
     req->data.sender   = NodeIdFromTag(info->sender_tag);
+    rx_mu_.unlock();
     UCX_LOGE(2, " rx meta, sender " << req->data.sender << " tag "
              << info->sender_tag << " compl " << req->completed);
     return req;
@@ -732,13 +760,13 @@ private:
     UCX_REQUEST_FREE(req); // can release request back to UCX now
   }
 
-  static void TxReqCompletedCb(void *request, ucs_status_t status)
+  static void TxReqCompletedCb(void *request, ucs_status_t status, void *user_data)
   {
     UCXRequest *req = reinterpret_cast<UCXRequest*>(request);
 
     CHECK_STATUS(status) << "TX request completed with " << ucs_status_string(status);
 
-    delete [] req->data.raw_meta;
+    delete [] user_data;
 
     UCX_REQUEST_FREE(req);
   }
@@ -751,6 +779,7 @@ private:
   Node                                              *my_node_;
   UCXVan                                            *van_;
   UCXRecvPool                                       *rx_pool_;
+  std::mutex                                        rx_mu_;
 };
 
 class UCXVan : public Van {
@@ -959,10 +988,7 @@ class UCXVan : public Van {
     ucs_status_ptr_t st = ContextById(src_dev_id)->Send(msg, buf, count, dt,
                                                         ps::Tags::UCX_TAG_META);
     UCX_LOG(2, "after Send");
-    if (UCS_PTR_IS_PTR(st)) {
-      UCXRequest *req    = reinterpret_cast<UCXRequest*>(st);
-      req->data.raw_meta = meta_buf;
-    } else {
+    if (!UCS_PTR_IS_PTR(st)) {
       // Send was completed immediately
       delete[] meta_buf;
       if (UCS_PTR_IS_ERR(st)) {


### PR DESCRIPTION
Send and receive threads should not be interrupted by polling thread between send/receive operation and request initialization.
For send flow fixed by using new ucp_tag_send_nbx API
for receive flow added extra mutex. To be replaced by *recv_nbx API later (when everything is ready in UCX)