### PR TITLE
add option for lockless queue

### DIFF
--- a/include/ps/internal/spsc_queue.h
+++ b/include/ps/internal/spsc_queue.h
@@ -1,0 +1,178 @@
+/*
+Copyright (c) 2018 Erik Rigtorp <erik@rigtorp.se>
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+#ifndef SPSC_QUEUE_H
+#define SPSC_QUEUE_H
+
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <new>
+#include <stdexcept>
+#include <type_traits>
+
+namespace rigtorp {
+
+template <typename T> class SPSCQueue {
+public:
+  explicit SPSCQueue(const size_t capacity)
+      : capacity_(capacity),
+        slots_(capacity_ < 2 ? nullptr
+                             : static_cast<T *>(operator new[](
+                                   sizeof(T) * (capacity_ + 2 * kPadding)))),
+        head_(0), tail_(0) {
+    if (capacity_ < 2) {
+      throw std::invalid_argument("size < 2");
+    }
+    static_assert(alignof(SPSCQueue<T>) == kCacheLineSize, "");
+    static_assert(sizeof(SPSCQueue<T>) >= 3 * kCacheLineSize, "");
+    assert(reinterpret_cast<char *>(&tail_) -
+               reinterpret_cast<char *>(&head_) >=
+           static_cast<std::ptrdiff_t>(kCacheLineSize));
+  }
+
+  ~SPSCQueue() {
+    while (front()) {
+      pop();
+    }
+    operator delete[](slots_);
+  }
+
+  // non-copyable and non-movable
+  SPSCQueue(const SPSCQueue &) = delete;
+  SPSCQueue &operator=(const SPSCQueue &) = delete;
+
+  template <typename... Args>
+  void emplace(Args &&... args) noexcept(
+      std::is_nothrow_constructible<T, Args &&...>::value) {
+    static_assert(std::is_constructible<T, Args &&...>::value,
+                  "T must be constructible with Args&&...");
+    auto const head = head_.load(std::memory_order_relaxed);
+    auto nextHead = head + 1;
+    if (nextHead == capacity_) {
+      nextHead = 0;
+    }
+    while (nextHead == tail_.load(std::memory_order_acquire))
+      ;
+    new (&slots_[head + kPadding]) T(std::forward<Args>(args)...);
+    head_.store(nextHead, std::memory_order_release);
+  }
+
+  template <typename... Args>
+  bool try_emplace(Args &&... args) noexcept(
+      std::is_nothrow_constructible<T, Args &&...>::value) {
+    static_assert(std::is_constructible<T, Args &&...>::value,
+                  "T must be constructible with Args&&...");
+    auto const head = head_.load(std::memory_order_relaxed);
+    auto nextHead = head + 1;
+    if (nextHead == capacity_) {
+      nextHead = 0;
+    }
+    if (nextHead == tail_.load(std::memory_order_acquire)) {
+      return false;
+    }
+    new (&slots_[head + kPadding]) T(std::forward<Args>(args)...);
+    head_.store(nextHead, std::memory_order_release);
+    return true;
+  }
+
+  void push(const T &v) noexcept(std::is_nothrow_copy_constructible<T>::value) {
+    static_assert(std::is_copy_constructible<T>::value,
+                  "T must be copy constructible");
+    emplace(v);
+  }
+
+  template <typename P, typename = typename std::enable_if<
+                            std::is_constructible<T, P &&>::value>::type>
+  void push(P &&v) noexcept(std::is_nothrow_constructible<T, P &&>::value) {
+    emplace(std::forward<P>(v));
+  }
+
+  bool
+  try_push(const T &v) noexcept(std::is_nothrow_copy_constructible<T>::value) {
+    static_assert(std::is_copy_constructible<T>::value,
+                  "T must be copy constructible");
+    return try_emplace(v);
+  }
+
+  template <typename P, typename = typename std::enable_if<
+                            std::is_constructible<T, P &&>::value>::type>
+  bool try_push(P &&v) noexcept(std::is_nothrow_constructible<T, P &&>::value) {
+    return try_emplace(std::forward<P>(v));
+  }
+
+  T *front() noexcept {
+    auto const tail = tail_.load(std::memory_order_relaxed);
+    if (head_.load(std::memory_order_acquire) == tail) {
+      return nullptr;
+    }
+    return &slots_[tail + kPadding];
+  }
+
+  void pop() noexcept {
+    static_assert(std::is_nothrow_destructible<T>::value,
+                  "T must be nothrow destructible");
+    auto const tail = tail_.load(std::memory_order_relaxed);
+    assert(head_.load(std::memory_order_acquire) != tail);
+    slots_[tail + kPadding].~T();
+    auto nextTail = tail + 1;
+    if (nextTail == capacity_) {
+      nextTail = 0;
+    }
+    tail_.store(nextTail, std::memory_order_release);
+  }
+
+  size_t size() const noexcept {
+    std::ptrdiff_t diff = head_.load(std::memory_order_acquire) -
+                          tail_.load(std::memory_order_acquire);
+    if (diff < 0) {
+      diff += capacity_;
+    }
+    return static_cast<size_t>(diff);
+  }
+
+  bool empty() const noexcept { return size() == 0; }
+
+  size_t capacity() const noexcept { return capacity_; }
+
+private:
+#ifdef __cpp_lib_hardware_interference_size
+  static constexpr size_t kCacheLineSize =
+      std::hardware_destructive_interference_size;
+#else
+  static constexpr size_t kCacheLineSize = 64;
+#endif
+
+  // Padding to avoid false sharing between slots_ and adjacent allocations
+  static constexpr size_t kPadding = (kCacheLineSize - 1) / sizeof(T) + 1;
+
+private:
+  const size_t capacity_;
+  T *const slots_;
+
+  // Align to avoid false sharing between head_ and tail_
+  alignas(kCacheLineSize) std::atomic<size_t> head_;
+  alignas(kCacheLineSize) std::atomic<size_t> tail_;
+
+  // Padding to avoid adjacent allocations to share cache line with tail_
+  char padding_[kCacheLineSize - sizeof(tail_)];
+};
+} // namespace rigtorp
+
+#endif

--- a/include/ps/internal/threadsafe_queue.h
+++ b/include/ps/internal/threadsafe_queue.h
@@ -8,6 +8,8 @@
 #include <condition_variable>
 #include <memory>
 #include "ps/base.h"
+#include "spsc_queue.h"
+
 namespace ps {
 
 /**
@@ -15,7 +17,14 @@ namespace ps {
  */
 template<typename T> class ThreadsafeQueue {
  public:
-  ThreadsafeQueue() { }
+  ThreadsafeQueue() : lockless_queue_(32768) {
+    auto lockless_str = getenv("DMLC_LOCKLESS_QUEUE");
+    lockless_ = lockless_str ? atoi(lockless_str) : true;
+    auto polling_str = getenv("DMLC_POLLING_IN_NANOSECOND");
+    int polling_duration_int = polling_str ? atoi(polling_str) : 1000;
+    polling_duration_ = std::chrono::nanoseconds(polling_duration_int);
+  }
+
   ~ThreadsafeQueue() { }
 
   /**
@@ -23,6 +32,10 @@ template<typename T> class ThreadsafeQueue {
    * \param new_value the value
    */
   void Push(T new_value) {
+    if (lockless_) {
+      PushLockless(std::move(new_value));
+      return;
+    }
     mu_.lock();
     queue_.push(std::move(new_value));
     mu_.unlock();
@@ -34,6 +47,10 @@ template<typename T> class ThreadsafeQueue {
    * \param value the poped value
    */
   void WaitAndPop(T* value) {
+    if (lockless_) {
+      WaitAndPopLockless(value);
+      return;
+    }
     std::unique_lock<std::mutex> lk(mu_);
     cond_.wait(lk, [this]{return !queue_.empty();});
     *value = std::move(queue_.front());
@@ -44,24 +61,62 @@ template<typename T> class ThreadsafeQueue {
    * \brief peek queue size
    */
   int Size() {
+    if (lockless_) {
+      return SizeLockless();
+    }
     std::unique_lock<std::mutex> lk(mu_);
     return queue_.size();
   }
 
  private:
+
+  // lockless impl
+  void PushLockless(T new_value) {
+    write_mu_.lock();
+    lockless_queue_.push(std::move(new_value));
+    write_mu_.unlock();
+  }
+
+  void WaitAndPopLockless(T* value) {
+    auto t = std::chrono::high_resolution_clock::now() + polling_duration_;
+    for (;;) {
+      read_mu_.lock();
+      if (lockless_queue_.front()) {
+        *value = *(lockless_queue_.front());
+        lockless_queue_.pop();
+        read_mu_.unlock();
+        break;
+      }
+      read_mu_.unlock();
+      if (std::chrono::high_resolution_clock::now() < t) {
+        std::this_thread::yield();
+      } else {
+        std::this_thread::sleep_for(std::chrono::microseconds(1));
+      }
+    }
+  }
+
+  int SizeLockless() {
+    std::unique_lock<std::mutex> lk_read(read_mu_);
+    std::unique_lock<std::mutex> lk_write(write_mu_);
+    return lockless_queue_.size();
+  }
+
+  bool lockless_;
+
+  // cv implementation
   mutable std::mutex mu_;
   std::queue<T> queue_;
   std::condition_variable cond_;
+
+  // lockless implementation
+  mutable std::mutex read_mu_;
+  mutable std::mutex write_mu_;
+  rigtorp::SPSCQueue<T> lockless_queue_;
+  std::chrono::nanoseconds polling_duration_;
+
 };
 
 }  // namespace ps
 
-// bool TryPop(T& value) {
-//   std::lock_guard<std::mutex> lk(mut);
-//   if(data_queue.empty())
-//     return false;
-//   value=std::move(data_queue.front());
-//   data_queue.pop();
-//   return true;
-// }
 #endif  // PS_INTERNAL_THREADSAFE_QUEUE_H_


### PR DESCRIPTION
Upstream the lockless changes (mainly done by Yibo). Tested with the following command:

```
NUM_KEY_PER_SERVER=400 ARGS="25600 1000000 2" UCX_NET_DEVICES=mlx5_0:1 PS_VERBOSE=0 UCX_HOME=/opt/tiger/haibin.lin/ps-lite-test-benchmark/ucx_shm_roce_build/ NODE_ONE_IP=10.212.255.206 NODE_TWO_IP=10.212.255.207 DMLC_NUM_PORTS=1 SKIP_DEV_ID_CHECK=1 UCX_MAX_RNDV_RAILS=1 DMLC_NUM_GPU_DEV=0 DMLC_NUM_CPU_DEV=1 ENABLE_RECV_BUFFER=0 TEST_NUM_GPU_WORKER=0 TEST_NUM_GPU_SERVER=0 TEST_NUM_CPU_WORKER=1 TEST_NUM_CPU_SERVER=1 numactl -m 1 -N 1  bash ./test.sh (local|remote)
```

Goodput increases slightly (37 Gb/s -> 39 Gb/s). 

To disable lockless queue, set DMLC_LOCKLESS_QUEUE=0. 
The polling duration `DMLC_POLLING_IN_NANOSECOND` is tunable. @brminich

@pleasantrabbit @ymjiang FYI
