### PR TITLE
Support multiple ps-lite instance in a process

### DIFF
--- a/include/ps/internal/message.h
+++ b/include/ps/internal/message.h
@@ -146,7 +146,7 @@ struct Control {
     if (empty()) return "";
     std::vector<std::string> cmds = {
       "EMPTY", "TERMINATE", "ADD_NODE", "BARRIER", "ACK", "HEARTBEAT", "BOOTSTRAP", "ADDR_REQUEST",
-      "ADDR_RESOLVED"
+      "ADDR_RESOLVED", "INSTANCE_BARRIER"
     };
     std::stringstream ss;
     ss << "cmd=" << cmds[cmd];
@@ -155,13 +155,13 @@ struct Control {
       for (const Node& n : node) ss << " " << n.DebugString();
       ss << " }";
     }
-    if (cmd == BARRIER) ss << ", barrier_group=" << barrier_group;
+    if (cmd == BARRIER || cmd == INSTANCE_BARRIER) ss << ", barrier_group=" << barrier_group;
     if (cmd == ACK) ss << ", msg_sig=" << msg_sig;
     return ss.str();
   }
   /** \brief all commands */
   enum Command { EMPTY, TERMINATE, ADD_NODE, BARRIER, ACK, HEARTBEAT, BOOTSTRAP, ADDR_REQUEST,
-                 ADDR_RESOLVED};
+                 ADDR_RESOLVED, INSTANCE_BARRIER};
   /** \brief the command */
   Command cmd;
   /** \brief node infos */

--- a/include/ps/internal/postoffice.h
+++ b/include/ps/internal/postoffice.h
@@ -18,49 +18,60 @@ namespace ps {
 class Postoffice {
  public:
   /**
-   * \brief return the Postoffice for server/scheduler if it exists. Otherwise
-   * return the one for worker
+   * \brief return the first Postoffice instance in the following order:
+   * scheduler, server, worker.
    */
   static Postoffice* Get() {
-    return po_server_ ? po_server_ : po_worker_;
+    CHECK(initialized_) << "Please call ps::StartPS() first";
+    if (po_scheduler_) return po_scheduler_;
+    if (po_server_group_.size()) return po_server_group_.at(0);
+    return po_worker_group_.at(0);
   }
 
-  static Postoffice* GetServer() {
-    std::lock_guard<std::mutex> lk(singleton_mu_);
-    if (!po_server_) {
-      po_server_ = new Postoffice;
-    }
-    return po_server_;
+  /**
+   * \brief return the Postoffice instance for scheduler if it exists.
+   * Otherwise, return the one for the server.
+   */
+  static Postoffice* GetServer(int index = 0) {
+    CHECK(initialized_) << "Please call ps::StartPS() first";
+    if (po_scheduler_) return po_scheduler_;
+    return po_server_group_.at(index);
   }
 
+  /**
+   * \brief return the Postoffice instance for scheduler.
+   */
   static Postoffice* GetScheduler() {
-    std::lock_guard<std::mutex> lk(singleton_mu_);
-    if (!po_scheduler_) {
-      po_scheduler_ = new Postoffice;
-    }
+    CHECK(initialized_) << "Please call ps::StartPS() first";
     return po_scheduler_;
   }
 
-  static Postoffice* GetWorker() {
-    std::lock_guard<std::mutex> lk(singleton_mu_);
-    if (!po_worker_) {
-      po_worker_ = new Postoffice;
-    }
-    return po_worker_;
+  /**
+   * \brief return the Postoffice instance for worker.
+   * \param index the instance offset inside the worker group.
+   * it should be less than DMLC_GROUP_SIZE.
+   */
+  static Postoffice* GetWorker(int index = 0) {
+    CHECK(initialized_) << "Please call ps::StartPS() first";
+    return po_worker_group_.at(index);
   }
 
   /** \brief get the van */
   Van* van() { return van_; }
+
   /**
    * \brief start the system
    *
-   * This function will block until every nodes are started.
-   * \param argv0 the program name, used for logging.
-   * \param preferred_rank the preferred rank. -1 means no preference and the rank will be assigned by
-      the scheduler. If the rank is non-negative, the preferred rank will be assigned accordingly.
+   * This function will block until every nodes are started if do_barrier is True.
+   * \param customer_id the customer id
+   * \param role the role of the postoffice
+   * \param rank the rank. -1 means no preference and the rank will be assigned by
+      the scheduler.
    * \param do_barrier whether to block until every nodes are started.
+   * \param argv0 the program name, used for logging.
    */
   void Start(int customer_id, const Node::Role role, int rank, const bool do_barrier, const char* argv0);
+
   /**
    * \brief terminate the system
    *
@@ -85,10 +96,10 @@ class Postoffice {
    */
   Customer* GetCustomer(int app_id, int customer_id, int timeout = 0) const;
   /**
-   * \brief get the id of a node (group), threadsafe
+   * \brief get the ids of a role group, threadsafe
    *
-   * if it is a  node group, return the list of node ids in this
-   * group. otherwise, return {node_id}
+   * if it is a node group, return the list of postoffice INSTANCE ids in this
+   * role group. otherwise, return {node_id}
    */
   const std::vector<int>& GetNodeIDs(int node_id) const {
     const auto it = node_ids_.find(node_id);
@@ -96,7 +107,7 @@ class Postoffice {
     return it->second;
   }
   /**
-   * \brief return the key ranges of all server nodes
+   * \brief return the key ranges of all server GROUP nodes
    */
   const std::vector<Range>& GetServerKeyRanges();
   /**
@@ -121,6 +132,39 @@ class Postoffice {
   void RegisterExitCallback(const Callback& cb) {
     exit_callback_ = cb;
   }
+
+  /**
+   * \brief convert a worker group's rank into a instance id with the
+   * provded group offset from that group
+   * \param rank the worker group rank
+   * \param group_offset the offset of the instance in the group
+   */
+  inline int GroupWorkerRankToInstanceID(int rank, int group_offset) {
+    int instance_rank = rank * group_size_ + group_offset;
+    return WorkerRankToID(instance_rank);
+  }
+
+  /**
+   * \brief convert a server group's rank into a instance id with the
+   * provded group offset from that group
+   * \param rank the server group rank
+   * \param group_offset the offset of the instance in the group
+   */
+  inline int GroupServerRankToInstanceID(int rank, int group_offset) {
+    int instance_rank = rank * group_size_ + group_offset;
+    return ServerRankToID(instance_rank);
+  }
+
+  /**
+   * \brief convert an instance id into a server group or worker group rank
+   * \param id the instance id
+   */
+  inline int InstanceIDtoGroupRank(int id) {
+    int instance_rank = IDtoRank(id);
+    int group_rank = instance_rank / group_size_;
+    return group_rank;
+  }
+
   /**
    * \brief convert from a worker rank into a node id
    * \param rank the worker rank
@@ -145,11 +189,18 @@ class Postoffice {
 #endif
     return std::max((id - 8) / 2, 0);
   }
-  /** \brief Returns the number of worker nodes */
+  /** \brief Returns the size of a worker/server group */
+  int group_size() const { return group_size_; }
+  /** \brief Returns the number of worker groups */
   int num_workers() const { return num_workers_; }
-  /** \brief Returns the number of server nodes */
+  /** \brief Returns the number of server groups */
   int num_servers() const { return num_servers_; }
-  /** \brief Returns the rank of this node in its group
+  /** \brief Returns the number of worker instances */
+  int num_worker_instances() const { return num_workers_ * group_size_; }
+  /** \brief Returns the number of server instances */
+  int num_server_instances() const { return num_servers_ * group_size_; }
+
+  /** \brief Returns the rank of this node in its role group
    *
    * Each worker will have a unique rank within [0, NumWorkers()). So are
    * servers. This function is available only after \ref Start has been called.
@@ -200,14 +251,34 @@ class Postoffice {
    */
   std::vector<int> GetDeadNodes(int t = 60);
 
+  // initialize all instances in the group for this role
+  static void Init(ps::Node::Role role);
+
  private:
-  Postoffice();
+  /**
+   * \param group_offset the offset of the instance inside the group.
+   * It should be less than DMLC_GROUP_SIZE
+   */
+  Postoffice(int group_offset);
   ~Postoffice() { delete van_; }
 
-  static Postoffice* po_server_;
+  /**
+   * \brief barrier for all postoffice instances or groups
+   * \param customer_id the id of the customer
+   * \param node_id the barrier group id
+   * \param instance_barrier whether it's for all postoffice instances or groups
+   */
+  void DoBarrier(int customer_id, int node_group, bool instance_barrier);
+
   static Postoffice* po_scheduler_;
-  static Postoffice* po_worker_;
-  static std::mutex singleton_mu_;
+  static std::mutex init_mu_;
+  // the group of postoffices for workers
+  static std::vector<Postoffice*> po_worker_group_;
+  // the group of postoffices for servers
+  static std::vector<Postoffice*> po_server_group_;
+
+  // initialization
+  static bool initialized_;
 
   void InitEnvironment();
   Van* van_;
@@ -218,7 +289,7 @@ class Postoffice {
   std::mutex server_key_ranges_mu_;
   std::vector<Range> server_key_ranges_;
   bool is_worker_, is_server_, is_scheduler_;
-  int num_servers_, num_workers_;
+  int num_servers_, num_workers_, group_size_;
 
   // a hint for preferred rank
   int preferred_rank_;
@@ -229,6 +300,7 @@ class Postoffice {
   std::mutex heartbeat_mu_;
   std::mutex start_mu_;
   int init_stage_ = 0;
+  int group_offset_ = 0;
   std::unordered_map<int, time_t> heartbeats_;
   Callback exit_callback_;
   /** \brief Holding a shared_ptr to prevent it from being destructed too early */

--- a/include/ps/internal/postoffice.h
+++ b/include/ps/internal/postoffice.h
@@ -139,10 +139,10 @@ class Postoffice {
    * \brief convert a worker group's rank into a instance id with the
    * provded instance offset from that group
    * \param rank the worker group rank
-   * \param instance_offset the offset of the instance in the group
+   * \param instance_idx the offset of the instance in the group
    */
-  inline int GroupWorkerRankToInstanceID(int rank, int instance_offset) {
-    int instance_rank = rank * group_size_ + instance_offset;
+  inline int GroupWorkerRankToInstanceID(int rank, int instance_idx) {
+    int instance_rank = rank * group_size_ + instance_idx;
     return WorkerRankToID(instance_rank);
   }
 
@@ -150,10 +150,10 @@ class Postoffice {
    * \brief convert a server group's rank into a instance id with the
    * provded instance offset from that group
    * \param rank the server group rank
-   * \param instance_offset the offset of the instance in the group
+   * \param instance_idx the offset of the instance in the group
    */
-  inline int GroupServerRankToInstanceID(int rank, int instance_offset) {
-    int instance_rank = rank * group_size_ + instance_offset;
+  inline int GroupServerRankToInstanceID(int rank, int instance_idx) {
+    int instance_rank = rank * group_size_ + instance_idx;
     return ServerRankToID(instance_rank);
   }
 
@@ -258,10 +258,10 @@ class Postoffice {
 
  private:
   /**
-   * \param instance_offset the offset of the instance inside the group.
+   * \param instance_idx the offset of the instance inside the group.
    * It should be less than DMLC_GROUP_SIZE
    */
-  Postoffice(int instance_offset);
+  Postoffice(int instance_idx);
   ~Postoffice() { delete van_; }
 
   /**
@@ -302,7 +302,7 @@ class Postoffice {
   std::mutex heartbeat_mu_;
   std::mutex start_mu_;
   int init_stage_ = 0;
-  int instance_offset_ = 0;
+  int instance_idx_ = 0;
   std::unordered_map<int, time_t> heartbeats_;
   Callback exit_callback_;
   /** \brief Holding a shared_ptr to prevent it from being destructed too early */

--- a/include/ps/internal/spsc_queue.h
+++ b/include/ps/internal/spsc_queue.h
@@ -1,0 +1,178 @@
+/*
+Copyright (c) 2018 Erik Rigtorp <erik@rigtorp.se>
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+#ifndef SPSC_QUEUE_H
+#define SPSC_QUEUE_H
+
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <new>
+#include <stdexcept>
+#include <type_traits>
+
+namespace rigtorp {
+
+template <typename T> class SPSCQueue {
+public:
+  explicit SPSCQueue(const size_t capacity)
+      : capacity_(capacity),
+        slots_(capacity_ < 2 ? nullptr
+                             : static_cast<T *>(operator new[](
+                                   sizeof(T) * (capacity_ + 2 * kPadding)))),
+        head_(0), tail_(0) {
+    if (capacity_ < 2) {
+      throw std::invalid_argument("size < 2");
+    }
+    static_assert(alignof(SPSCQueue<T>) == kCacheLineSize, "");
+    static_assert(sizeof(SPSCQueue<T>) >= 3 * kCacheLineSize, "");
+    assert(reinterpret_cast<char *>(&tail_) -
+               reinterpret_cast<char *>(&head_) >=
+           static_cast<std::ptrdiff_t>(kCacheLineSize));
+  }
+
+  ~SPSCQueue() {
+    while (front()) {
+      pop();
+    }
+    operator delete[](slots_);
+  }
+
+  // non-copyable and non-movable
+  SPSCQueue(const SPSCQueue &) = delete;
+  SPSCQueue &operator=(const SPSCQueue &) = delete;
+
+  template <typename... Args>
+  void emplace(Args &&... args) noexcept(
+      std::is_nothrow_constructible<T, Args &&...>::value) {
+    static_assert(std::is_constructible<T, Args &&...>::value,
+                  "T must be constructible with Args&&...");
+    auto const head = head_.load(std::memory_order_relaxed);
+    auto nextHead = head + 1;
+    if (nextHead == capacity_) {
+      nextHead = 0;
+    }
+    while (nextHead == tail_.load(std::memory_order_acquire))
+      ;
+    new (&slots_[head + kPadding]) T(std::forward<Args>(args)...);
+    head_.store(nextHead, std::memory_order_release);
+  }
+
+  template <typename... Args>
+  bool try_emplace(Args &&... args) noexcept(
+      std::is_nothrow_constructible<T, Args &&...>::value) {
+    static_assert(std::is_constructible<T, Args &&...>::value,
+                  "T must be constructible with Args&&...");
+    auto const head = head_.load(std::memory_order_relaxed);
+    auto nextHead = head + 1;
+    if (nextHead == capacity_) {
+      nextHead = 0;
+    }
+    if (nextHead == tail_.load(std::memory_order_acquire)) {
+      return false;
+    }
+    new (&slots_[head + kPadding]) T(std::forward<Args>(args)...);
+    head_.store(nextHead, std::memory_order_release);
+    return true;
+  }
+
+  void push(const T &v) noexcept(std::is_nothrow_copy_constructible<T>::value) {
+    static_assert(std::is_copy_constructible<T>::value,
+                  "T must be copy constructible");
+    emplace(v);
+  }
+
+  template <typename P, typename = typename std::enable_if<
+                            std::is_constructible<T, P &&>::value>::type>
+  void push(P &&v) noexcept(std::is_nothrow_constructible<T, P &&>::value) {
+    emplace(std::forward<P>(v));
+  }
+
+  bool
+  try_push(const T &v) noexcept(std::is_nothrow_copy_constructible<T>::value) {
+    static_assert(std::is_copy_constructible<T>::value,
+                  "T must be copy constructible");
+    return try_emplace(v);
+  }
+
+  template <typename P, typename = typename std::enable_if<
+                            std::is_constructible<T, P &&>::value>::type>
+  bool try_push(P &&v) noexcept(std::is_nothrow_constructible<T, P &&>::value) {
+    return try_emplace(std::forward<P>(v));
+  }
+
+  T *front() noexcept {
+    auto const tail = tail_.load(std::memory_order_relaxed);
+    if (head_.load(std::memory_order_acquire) == tail) {
+      return nullptr;
+    }
+    return &slots_[tail + kPadding];
+  }
+
+  void pop() noexcept {
+    static_assert(std::is_nothrow_destructible<T>::value,
+                  "T must be nothrow destructible");
+    auto const tail = tail_.load(std::memory_order_relaxed);
+    assert(head_.load(std::memory_order_acquire) != tail);
+    slots_[tail + kPadding].~T();
+    auto nextTail = tail + 1;
+    if (nextTail == capacity_) {
+      nextTail = 0;
+    }
+    tail_.store(nextTail, std::memory_order_release);
+  }
+
+  size_t size() const noexcept {
+    std::ptrdiff_t diff = head_.load(std::memory_order_acquire) -
+                          tail_.load(std::memory_order_acquire);
+    if (diff < 0) {
+      diff += capacity_;
+    }
+    return static_cast<size_t>(diff);
+  }
+
+  bool empty() const noexcept { return size() == 0; }
+
+  size_t capacity() const noexcept { return capacity_; }
+
+private:
+#ifdef __cpp_lib_hardware_interference_size
+  static constexpr size_t kCacheLineSize =
+      std::hardware_destructive_interference_size;
+#else
+  static constexpr size_t kCacheLineSize = 64;
+#endif
+
+  // Padding to avoid false sharing between slots_ and adjacent allocations
+  static constexpr size_t kPadding = (kCacheLineSize - 1) / sizeof(T) + 1;
+
+private:
+  const size_t capacity_;
+  T *const slots_;
+
+  // Align to avoid false sharing between head_ and tail_
+  alignas(kCacheLineSize) std::atomic<size_t> head_;
+  alignas(kCacheLineSize) std::atomic<size_t> tail_;
+
+  // Padding to avoid adjacent allocations to share cache line with tail_
+  char padding_[kCacheLineSize - sizeof(tail_)];
+};
+} // namespace rigtorp
+
+#endif

--- a/include/ps/internal/threadsafe_queue.h
+++ b/include/ps/internal/threadsafe_queue.h
@@ -8,6 +8,8 @@
 #include <condition_variable>
 #include <memory>
 #include "ps/base.h"
+#include "spsc_queue.h"
+
 namespace ps {
 
 /**
@@ -15,7 +17,14 @@ namespace ps {
  */
 template<typename T> class ThreadsafeQueue {
  public:
-  ThreadsafeQueue() { }
+  ThreadsafeQueue() : lockless_queue_(32768) {
+    auto lockless_str = getenv("DMLC_LOCKLESS_QUEUE");
+    lockless_ = lockless_str ? atoi(lockless_str) : true;
+    auto polling_str = getenv("DMLC_POLLING_IN_NANOSECOND");
+    int polling_duration_int = polling_str ? atoi(polling_str) : 1000;
+    polling_duration_ = std::chrono::nanoseconds(polling_duration_int);
+  }
+
   ~ThreadsafeQueue() { }
 
   /**
@@ -23,6 +32,10 @@ template<typename T> class ThreadsafeQueue {
    * \param new_value the value
    */
   void Push(T new_value) {
+    if (lockless_) {
+      PushLockless(std::move(new_value));
+      return;
+    }
     mu_.lock();
     queue_.push(std::move(new_value));
     mu_.unlock();
@@ -34,6 +47,10 @@ template<typename T> class ThreadsafeQueue {
    * \param value the poped value
    */
   void WaitAndPop(T* value) {
+    if (lockless_) {
+      WaitAndPopLockless(value);
+      return;
+    }
     std::unique_lock<std::mutex> lk(mu_);
     cond_.wait(lk, [this]{return !queue_.empty();});
     *value = std::move(queue_.front());
@@ -44,24 +61,62 @@ template<typename T> class ThreadsafeQueue {
    * \brief peek queue size
    */
   int Size() {
+    if (lockless_) {
+      return SizeLockless();
+    }
     std::unique_lock<std::mutex> lk(mu_);
     return queue_.size();
   }
 
  private:
+
+  // lockless impl
+  void PushLockless(T new_value) {
+    write_mu_.lock();
+    lockless_queue_.push(std::move(new_value));
+    write_mu_.unlock();
+  }
+
+  void WaitAndPopLockless(T* value) {
+    auto t = std::chrono::high_resolution_clock::now() + polling_duration_;
+    for (;;) {
+      read_mu_.lock();
+      if (lockless_queue_.front()) {
+        *value = *(lockless_queue_.front());
+        lockless_queue_.pop();
+        read_mu_.unlock();
+        break;
+      }
+      read_mu_.unlock();
+      if (std::chrono::high_resolution_clock::now() < t) {
+        std::this_thread::yield();
+      } else {
+        std::this_thread::sleep_for(std::chrono::microseconds(1));
+      }
+    }
+  }
+
+  int SizeLockless() {
+    std::unique_lock<std::mutex> lk_read(read_mu_);
+    std::unique_lock<std::mutex> lk_write(write_mu_);
+    return lockless_queue_.size();
+  }
+
+  bool lockless_;
+
+  // cv implementation
   mutable std::mutex mu_;
   std::queue<T> queue_;
   std::condition_variable cond_;
+
+  // lockless implementation
+  mutable std::mutex read_mu_;
+  mutable std::mutex write_mu_;
+  rigtorp::SPSCQueue<T> lockless_queue_;
+  std::chrono::nanoseconds polling_duration_;
+
 };
 
 }  // namespace ps
 
-// bool TryPop(T& value) {
-//   std::lock_guard<std::mutex> lk(mut);
-//   if(data_queue.empty())
-//     return false;
-//   value=std::move(data_queue.front());
-//   data_queue.pop();
-//   return true;
-// }
 #endif  // PS_INTERNAL_THREADSAFE_QUEUE_H_

--- a/include/ps/internal/van.h
+++ b/include/ps/internal/van.h
@@ -171,13 +171,19 @@ class Van {
   std::atomic<bool> ready_{false};
   std::atomic<size_t> send_bytes_{0};
   size_t recv_bytes_ = 0;
+  // number of server instances
   int num_servers_ = 0;
+  // number of worker instances
   int num_workers_ = 0;
   /** the thread for receiving messages */
   std::unique_ptr<std::thread> receiver_thread_;
   /** the thread for sending heartbeat */
   std::unique_ptr<std::thread> heartbeat_thread_;
+  // the count of instance barrier requests, used for instance-level barrier
   std::vector<int> barrier_count_;
+  // the id of (group) barrier request senders, used for group-level barrier
+  std::unordered_map<int, std::vector<int>> group_barrier_requests_;
+
   /** msg resender */
   Resender *resender_ = nullptr;
   int drop_rate_ = 0;
@@ -201,9 +207,14 @@ class Van {
   void ProcessAddNodeCommand(Message *msg, Meta *nodes, Meta *recovery_nodes);
 
   /**
-   * \brief processing logic of Barrier message (run on each node)
+   * \brief processing logic of group-level Barrier message (run on each postoffice instance group)
    */
   void ProcessBarrierCommand(Message *msg);
+
+  /**
+  * \brief processing logic of instance-level Barrier message (run on each postoffice instance)
+  */
+  void ProcessInstanceBarrierCommand(Message *msg);
 
   /**
    * \brief processing logic of AddNode message (run on each node)

--- a/include/ps/kv_app.h
+++ b/include/ps/kv_app.h
@@ -85,8 +85,13 @@ class KVWorker : public SimpleApp {
    * \param app_id the app id, should match with \ref KVServer's id
    * \param customer_id the customer id which is unique locally
    */
-  explicit KVWorker(int app_id, int customer_id) : SimpleApp() {
-    postoffice_ = Postoffice::GetWorker();
+  explicit KVWorker(int app_id, int customer_id, int group_offset = 0) : SimpleApp() {
+    postoffice_ = Postoffice::GetWorker(group_offset);
+    PS_VLOG(3) << "KVWorker " << group_offset << " po@" << (long long) postoffice_;
+    group_offset_ = group_offset;
+    int group_size = postoffice_->group_size();
+    CHECK(group_size > group_offset);
+
     using namespace std::placeholders;
     slicer_ = std::bind(&KVWorker<Val>::DefaultSlicer, this, _1, _2, _3);
     obj_ = new Customer(app_id, customer_id, std::bind(&KVWorker<Val>::Process, this, _1), postoffice_);
@@ -309,7 +314,7 @@ class KVWorker : public SimpleApp {
   /** \brief kv list slicer */
   Slicer slicer_;
 
-  Postoffice* postoffice_;
+  int group_offset_;
 };
 
 /** \brief meta information about a kv request */
@@ -345,10 +350,12 @@ class KVServer : public SimpleApp {
    * \brief constructor
    * \param app_id the app id, should match with \ref KVWorker's id
    */
-  explicit KVServer(int app_id, bool is_scheduler = false) : SimpleApp() {
-    postoffice_ = is_scheduler ? Postoffice::GetScheduler() : Postoffice::GetServer();
+  explicit KVServer(int app_id, bool is_scheduler = false, int group_offset = 0) : SimpleApp() {
+    postoffice_ = is_scheduler ? Postoffice::GetScheduler() : Postoffice::GetServer(group_offset);
+    CHECK(postoffice_) << is_scheduler << " " << group_offset;
+    group_offset_ = group_offset;
     using namespace std::placeholders;
-    obj_ = new Customer(app_id, app_id, std::bind(&KVServer<Val>::Process, this, _1), postoffice_);
+    this->obj_ = new Customer(app_id, app_id, std::bind(&KVServer::Process, this, _1), postoffice_);
   }
 
   /** \brief deconstructor */
@@ -402,8 +409,8 @@ class KVServer : public SimpleApp {
   std::mutex mu_;
   /** \brief lock for profile logging */
   std::mutex log_mu_;
-
-  Postoffice* postoffice_;
+  /** \brief the offset in the instance group */
+  int group_offset_;
 };
 
 
@@ -442,11 +449,16 @@ void KVServer<Val>::RegisterRecvBuffer(int worker_id, SArray<Key>& keys,
                                        const SArray<Val>& vals,
                                        const SArray<int>& lens,
                                        int cmd) {
+  // server group support
+  int group_worker_id = worker_id;
+  int group_worker_rank = postoffice_->IDtoRank(group_worker_id);
+  int instance_worker_id = postoffice_->GroupWorkerRankToInstanceID(group_worker_rank, group_offset_);
+
   Message msg;
   msg.meta.request = true;
   msg.meta.push = true;
   msg.meta.head = cmd;
-  msg.meta.sender = worker_id;
+  msg.meta.sender = instance_worker_id;
   CHECK(keys.size());
   msg.AddData(keys);
   msg.AddData(vals);
@@ -462,10 +474,15 @@ void KVServer<Val>::Process(const Message& msg) {
   if (msg.meta.simple_app) {
     SimpleApp::Process(msg); return;
   }
+  // server group support
+  int instance_worker_id = msg.meta.sender;
+  int group_worker_rank = postoffice_->InstanceIDtoGroupRank(instance_worker_id);
+  int group_worker_id = postoffice_->WorkerRankToID(group_worker_rank);
+
   KVMeta meta;
   meta.cmd       = msg.meta.head;
   meta.push      = msg.meta.push;
-  meta.sender    = msg.meta.sender;
+  meta.sender    = group_worker_id;
   meta.timestamp = msg.meta.timestamp;
   meta.customer_id = msg.meta.customer_id;
   meta.key       = msg.meta.key;
@@ -492,6 +509,13 @@ void KVServer<Val>::Process(const Message& msg) {
 
 template <typename Val>
 void KVServer<Val>::Response(const KVMeta& req, const KVPairs<Val>& res) {
+  // server group support
+  int group_worker_id = req.sender;
+  int group_worker_rank = postoffice_->IDtoRank(group_worker_id);
+  int instance_worker_id = postoffice_->GroupWorkerRankToInstanceID(group_worker_rank, group_offset_);
+  // TODO: remove logging
+  PS_VLOG(3) << "server instance " << group_offset_ << " response to " << instance_worker_id;
+
   Message msg;
   msg.meta.app_id = obj_->app_id();
   msg.meta.customer_id = req.customer_id;
@@ -499,7 +523,7 @@ void KVServer<Val>::Response(const KVMeta& req, const KVPairs<Val>& res) {
   msg.meta.push        = req.push;
   msg.meta.head        = req.cmd;
   msg.meta.timestamp   = req.timestamp;
-  msg.meta.recver      = req.sender;
+  msg.meta.recver      = instance_worker_id;
   msg.meta.key         = req.key;
   msg.meta.addr        = req.addr;
   msg.meta.val_len     = req.val_len;
@@ -511,7 +535,7 @@ void KVServer<Val>::Response(const KVMeta& req, const KVPairs<Val>& res) {
       msg.AddData(res.lens);
     }
   }
-  Postoffice::GetServer()->van()->Send(msg);
+  postoffice_->van()->Send(msg);
 }
 
 template <typename Val>
@@ -591,6 +615,12 @@ void KVWorker<Val>::Send(int timestamp, bool push, int cmd, KVPairs<Val>& kvs) {
   for (size_t i = 0; i < sliced.size(); ++i) {
     auto& s = sliced[i];
     if (!s.first) continue;
+
+    // worker group support
+    int group_server_rank = i;
+    int instance_server_id = postoffice_->GroupServerRankToInstanceID(group_server_rank, group_offset_);
+    // TODO: remove logging
+    PS_VLOG(3) << "worker instance " << group_offset_ << " send to " << instance_server_id;
     Message msg;
     msg.meta.app_id = obj_->app_id();
     msg.meta.customer_id = obj_->customer_id();
@@ -598,7 +628,7 @@ void KVWorker<Val>::Send(int timestamp, bool push, int cmd, KVPairs<Val>& kvs) {
     msg.meta.push        = push;
     msg.meta.head        = cmd;
     msg.meta.timestamp   = timestamp;
-    msg.meta.recver      = Postoffice::GetWorker()->ServerRankToID(i);
+    msg.meta.recver      = instance_server_id;
     auto& kvs = s.second;
     msg.meta.addr = reinterpret_cast<uint64_t>(kvs.vals.data());
     msg.meta.val_len = kvs.vals.size();
@@ -623,7 +653,7 @@ void KVWorker<Val>::Send(int timestamp, bool push, int cmd, KVPairs<Val>& kvs) {
       msg.meta.dst_dev_type = dst_dev_type;
       msg.meta.dst_dev_id = dst_dev_id;
     }
-    Postoffice::GetWorker()->van()->Send(msg);
+    postoffice_->van()->Send(msg);
   }
 }
 

--- a/include/ps/ps.h
+++ b/include/ps/ps.h
@@ -25,8 +25,9 @@ inline bool IsScheduler() { return Postoffice::Get()->is_scheduler(); }
  *
  * Each worker will have a unique rank within [0, NumWorkers()). So are
  * servers. This function is available only after \ref Start has been called.
+ * The rank is group-level based.
  */
-inline int MyRank() { return Postoffice::Get()->my_rank(); }
+inline int MyRank() { return Postoffice::Get()->my_rank() / Postoffice::Get()->group_size(); }
 /**
  * \brief start the system
  *
@@ -58,21 +59,117 @@ inline Node::Role GetRole(const std::string role_str) {
           the scheduler. If the rank is non-negative, the preferred rank will be assigned accordingly.
  * \param argv0 the program name, used for logging
  */
-inline void StartPS(int customer_id, Node::Role role, int rank, bool do_barrier, const char *argv0 = nullptr) {
+inline void _StartPS(int customer_id, Node::Role role, int rank, bool do_barrier,
+                     const char *argv0, int index) {
   if (role == Node::WORKER) {
-    Postoffice::GetWorker()->Start(customer_id, role, rank, do_barrier, argv0);
+    Postoffice::GetWorker(index)->Start(customer_id, role, rank, do_barrier, argv0);
   } else if (role == Node::SERVER || role == Node::SCHEDULER) {
-    Postoffice::GetServer()->Start(customer_id, role, rank, do_barrier, argv0);
+    Postoffice::GetServer(index)->Start(customer_id, role, rank, do_barrier, argv0);
   } else {
     // Joint PS: one worker, one server
-    std::thread thread_s(StartPS, customer_id, Node::SERVER, rank, do_barrier, argv0);
+    std::thread thread_s(_StartPS, customer_id, Node::SERVER, rank, do_barrier, argv0, index);
     LOG(INFO) << "Postoffice server started.";
 
-    std::thread thread_w(StartPS, customer_id, Node::WORKER, rank, do_barrier, argv0);
+    std::thread thread_w(_StartPS, customer_id, Node::WORKER, rank, do_barrier, argv0, index);
     LOG(INFO) << "Postoffice worker started.";
 
     thread_s.join();
     thread_w.join();
+  }
+}
+
+inline void _StartPSGroup(int customer_id, std::vector<int> worker_ranks,
+                          std::vector<int> server_ranks, bool do_barrier, const char *argv0 = nullptr) {
+  std::vector<std::thread> threads;
+  for (size_t i = 0; i < worker_ranks.size(); ++i) {
+    threads.emplace_back(_StartPS, customer_id, Node::WORKER, worker_ranks[i], do_barrier, argv0, i);
+    LOG(INFO) << "Postoffice worker rank " << worker_ranks[i] << " started.";
+  }
+  for (size_t i = 0; i < server_ranks.size(); ++i) {
+    threads.emplace_back(_StartPS, customer_id, Node::SERVER, server_ranks[i], do_barrier, argv0, i);
+    LOG(INFO) << "Postoffice server rank " << server_ranks[i] << " started.";
+  }
+  for (auto &t : threads) {
+    t.join();
+  }
+}
+
+/**
+ * \brief start the system. This can be called only ONCE
+ *
+ * \param customer_id the customer id
+ * \param role the node group / role: worker, server, scheduler, joint. joint role means
+               both having worker and server
+ * \param rank the preferred rank. -1 means no preference and the rank will be assigned by
+          the scheduler. If the rank is non-negative, the preferred rank will be assigned accordingly.
+ * \param do_barrier do a barrier to make sure every rank calls StartPS
+ * \param argv0 the program name, used for logging
+ * \param group_size the number of ps-lite instances per role
+ */
+inline void StartPS(int customer_id, Node::Role role, int rank, bool do_barrier,
+                    const char *argv0 = nullptr) {
+  auto val = Environment::Get()->find("DMLC_GROUP_SIZE");
+  int group_size = val ? atoi(val) : 1;
+
+  Postoffice::Init(role);
+  if (group_size == 1 || role == Node::SCHEDULER) {
+    int group_offset = 0;
+    _StartPS(customer_id, role, rank, do_barrier, argv0, group_offset);
+  } else {
+    CHECK(rank >= 0 && group_size > 0) << group_size;
+    std::vector<int> worker_ranks;
+    std::vector<int> server_ranks;
+    // start PS workers and servers as a group
+    if (role == Node::WORKER || role == Node::JOINT) {
+      for (int i = 0; i < group_size; ++i) {
+        int rank_i = rank * group_size + i;
+        worker_ranks.push_back(rank_i);
+      }
+    }
+    if (role == Node::SERVER || role == Node::JOINT) {
+      for (int i = 0; i < group_size; ++i) {
+        int rank_i = rank * group_size + i;
+        server_ranks.push_back(rank_i);
+      }
+    }
+    _StartPSGroup(customer_id, worker_ranks, server_ranks, do_barrier, argv0);
+  }
+}
+
+inline void _Finalize(int customer_id, Node::Role role, const bool do_barrier = true, int index = 0) {
+  if (role == Node::WORKER) {
+    Postoffice::GetWorker(index)->Finalize(customer_id, do_barrier);
+  } else if (role == Node::SERVER || role == Node::SCHEDULER) {
+    Postoffice::GetServer(index)->Finalize(customer_id, do_barrier);
+  } else {
+    // Joint PS: one worker, one server
+    std::thread thread_s(&Postoffice::Finalize, Postoffice::GetServer(index), customer_id, do_barrier);
+    LOG(INFO) << "Finalize Postoffice server.";
+
+    std::thread thread_w(&Postoffice::Finalize, Postoffice::GetWorker(index), customer_id, do_barrier);
+    LOG(INFO) << "Finalize Postoffice worker.";
+
+    thread_s.join();
+    thread_w.join();
+  }
+}
+
+inline void _FinalizeGroup(int customer_id, Node::Role role, int group_size, bool do_barrier) {
+  std::vector<std::thread> threads;
+  if (role == Node::JOINT || role == Node::WORKER) {
+    for (int i = 0; i < group_size; ++i) {
+      threads.emplace_back(&Postoffice::Finalize, Postoffice::GetWorker(i), customer_id, do_barrier);
+      LOG(INFO) << "Finalize worker instance " << i;
+    }
+  }
+  if (role == Node::JOINT || role == Node::SERVER) {
+    for (int i = 0; i < group_size; ++i) {
+      threads.emplace_back(&Postoffice::Finalize, Postoffice::GetServer(i), customer_id, do_barrier);
+      LOG(INFO) << "Finalize server instance " << i;
+    }
+  }
+  for (auto &t : threads) {
+    t.join();
   }
 }
 
@@ -83,22 +180,16 @@ inline void StartPS(int customer_id, Node::Role role, int rank, bool do_barrier,
  * \param do_barrier whether to block until every node is finalized, default true.
  */
 inline void Finalize(int customer_id, Node::Role role, const bool do_barrier = true) {
-  if (role == Node::WORKER) {
-    Postoffice::GetWorker()->Finalize(customer_id, do_barrier);
-  } else if (role == Node::SERVER || role == Node::SCHEDULER) {
-    Postoffice::GetServer()->Finalize(customer_id, do_barrier);
+  auto val = Environment::Get()->find("DMLC_GROUP_SIZE");
+  int group_size = val ? atoi(val) : 1;
+  if (group_size == 1 || role == Node::SCHEDULER) {
+    int group_offset = 0;
+    _Finalize(customer_id, role, do_barrier, group_offset);
   } else {
-    // Joint PS: one worker, one server
-    std::thread thread_s(&Postoffice::Finalize, Postoffice::GetServer(), customer_id, do_barrier);
-    LOG(INFO) << "Finalize Postoffice server.";
-
-    std::thread thread_w(&Postoffice::Finalize, Postoffice::GetWorker(), customer_id, do_barrier);
-    LOG(INFO) << "Finalize Postoffice worker.";
-
-    thread_s.join();
-    thread_w.join();
+    _FinalizeGroup(customer_id, role, group_size, do_barrier);
   }
 }
+
 /**
  * \brief Register a callback to the system which is called after Finalize()
  *

--- a/src/customer.cc
+++ b/src/customer.cc
@@ -30,8 +30,11 @@ Customer::~Customer() {
 }
 
 int Customer::NewRequest(int recver) {
+  CHECK(recver == kServerGroup) << recver;
   std::lock_guard<std::mutex> lk(tracker_mu_);
-  int num = postoffice_->GetNodeIDs(recver).size();
+  // for push/pull requests, the worker only communication with one instance from
+  // each server instance group
+  int num = postoffice_->GetNodeIDs(recver).size() / postoffice_->group_size();
   tracker_.push_back(std::make_pair(num, 0));
   return tracker_.size() - 1;
 }

--- a/src/postoffice.cc
+++ b/src/postoffice.cc
@@ -42,9 +42,9 @@ void Postoffice::Init(ps::Node::Role role) {
   initialized_ = true;
 }
 
-Postoffice::Postoffice(int instance_offset) {
+Postoffice::Postoffice(int instance_idx) {
   env_ref_ = Environment::_GetSharedRef();
-  instance_offset_ = instance_offset;
+  instance_idx_ = instance_idx;
 }
 
 void Postoffice::InitEnvironment() {

--- a/src/postoffice.cc
+++ b/src/postoffice.cc
@@ -11,13 +11,40 @@
 
 namespace ps {
 
-Postoffice* Postoffice::po_server_ = nullptr;
 Postoffice* Postoffice::po_scheduler_ = nullptr;
-Postoffice* Postoffice::po_worker_ = nullptr;
-std::mutex Postoffice::singleton_mu_;
+std::mutex Postoffice::init_mu_;
+std::vector<Postoffice*> Postoffice::po_worker_group_;
+std::vector<Postoffice*> Postoffice::po_server_group_;
+bool Postoffice::initialized_ = false;
 
-Postoffice::Postoffice() {
+void Postoffice::Init(ps::Node::Role role) {
+  std::lock_guard<std::mutex> lk(init_mu_);
+  if (initialized_) return;
+
+  int group_size = 1;
+  auto val = Environment::Get()->find("DMLC_GROUP_SIZE");
+  if (val) group_size = atoi(val);
+  CHECK(group_size >= 1);
+
+  if (role == ps::Node::SCHEDULER) {
+    po_scheduler_ = new Postoffice(0);
+  }
+  if (role == ps::Node::WORKER || role == ps::Node::JOINT) {
+    for (int i = 0; i < group_size; ++i) {
+      po_worker_group_.push_back(new Postoffice(i));
+    }
+  }
+  if (role == ps::Node::SERVER || role == ps::Node::JOINT) {
+    for (int i = 0; i < group_size; ++i) {
+      po_server_group_.push_back(new Postoffice(i));
+    }
+  }
+  initialized_ = true;
+}
+
+Postoffice::Postoffice(int group_offset) {
   env_ref_ = Environment::_GetSharedRef();
+  group_offset_ = group_offset;
 }
 
 void Postoffice::InitEnvironment() {
@@ -31,6 +58,9 @@ void Postoffice::InitEnvironment() {
     LOG(INFO) << "Creating Van: " << van_type;
     van_ = Van::Create(van_type, this);
   }
+  val = Environment::Get()->find("DMLC_GROUP_SIZE");
+  group_size_ = val ? atoi(val) : 1;
+  LOG(INFO) << "DMLC_GROUP_SIZE=" << group_size_;
   val = CHECK_NOTNULL(Environment::Get()->find("DMLC_NUM_WORKER"));
   num_workers_ = atoi(val);
   val =  CHECK_NOTNULL(Environment::Get()->find("DMLC_NUM_SERVER"));
@@ -83,8 +113,8 @@ void Postoffice::Start(int customer_id, const Node::Role role, int rank,
       dmlc::InitLogging("ps-lite\0");
     }
 
-    // init node info.
-    for (int i = 0; i < num_workers_; ++i) {
+    // init node info, for every worker/server instance
+    for (int i = 0; i < num_workers_ * group_size_; ++i) {
       int id = WorkerRankToID(i);
       for (int g : {id, kWorkerGroup, kWorkerGroup + kServerGroup,
                     kWorkerGroup + kScheduler,
@@ -93,7 +123,7 @@ void Postoffice::Start(int customer_id, const Node::Role role, int rank,
       }
     }
 
-    for (int i = 0; i < num_servers_; ++i) {
+    for (int i = 0; i < num_servers_ * group_size_; ++i) {
       int id = ServerRankToID(i);
       for (int g : {id, kServerGroup, kWorkerGroup + kServerGroup,
                     kServerGroup + kScheduler,
@@ -120,12 +150,18 @@ void Postoffice::Start(int customer_id, const Node::Role role, int rank,
     init_stage_++;
   }
   start_mu_.unlock();
-  // do a barrier here
-  if (do_barrier) Barrier(customer_id, kWorkerGroup + kServerGroup + kScheduler);
+  // do a barrier with all instances
+  if (do_barrier) {
+    bool instance_barrier = true;
+    DoBarrier(customer_id, kWorkerGroup + kServerGroup + kScheduler, instance_barrier);
+  }
 }
 
 void Postoffice::Finalize(const int customer_id, const bool do_barrier) {
-  if (do_barrier) Barrier(customer_id, kWorkerGroup + kServerGroup + kScheduler);
+  if (do_barrier) {
+    bool instance_barrier = true;
+    DoBarrier(customer_id, kWorkerGroup + kServerGroup + kScheduler, instance_barrier);
+  }
   if (customer_id == 0) {
     num_workers_ = 0;
     num_servers_ = 0;
@@ -181,9 +217,15 @@ Customer* Postoffice::GetCustomer(int app_id, int customer_id, int timeout) cons
   }
   return obj;
 }
-
-void Postoffice::Barrier(int customer_id, int node_group) {
-  if (GetNodeIDs(node_group).size() <= 1) return;
+/**
+ * \param customer_id the customer id
+ * \param node_group any combination of kScheduler, kWorkerGroup, kServerGroup
+ * \param instance_barrier whether to do a barrier with every instances, or every instance group
+ */
+void Postoffice::DoBarrier(int customer_id, int node_group, bool instance_barrier) {
+  int node_group_size = static_cast<int>(GetNodeIDs(node_group).size());
+  if (instance_barrier && node_group_size <= 1) return;
+  if (!instance_barrier && node_group_size <= group_size_) return;
   auto role = van_->my_node().role;
   if (role == Node::SCHEDULER) {
     CHECK(node_group & kScheduler);
@@ -197,7 +239,7 @@ void Postoffice::Barrier(int customer_id, int node_group) {
   Message req;
   req.meta.recver = kScheduler;
   req.meta.request = true;
-  req.meta.control.cmd = Control::BARRIER;
+  req.meta.control.cmd = instance_barrier ? Control::INSTANCE_BARRIER : Control::BARRIER;
   req.meta.app_id = 0;
   req.meta.customer_id = customer_id;
   req.meta.control.barrier_group = node_group;
@@ -206,6 +248,11 @@ void Postoffice::Barrier(int customer_id, int node_group) {
   barrier_cond_.wait(ulk, [this, customer_id] {
       return barrier_done_[0][customer_id];
     });
+}
+
+void Postoffice::Barrier(int customer_id, int node_group) {
+  // only do group-level barrier in the public API
+  DoBarrier(customer_id, node_group, false);
 }
 
 const std::vector<Range>& Postoffice::GetServerKeyRanges() {
@@ -224,7 +271,8 @@ const std::vector<Range>& Postoffice::GetServerKeyRanges() {
 void Postoffice::Manage(const Message& recv) {
   CHECK(!recv.meta.control.empty());
   const auto& ctrl = recv.meta.control;
-  if (ctrl.cmd == Control::BARRIER && !recv.meta.request) {
+  bool is_barrier = ctrl.cmd == Control::BARRIER || ctrl.cmd == Control::INSTANCE_BARRIER;
+  if (is_barrier && !recv.meta.request) {
     barrier_mu_.lock();
     auto size = barrier_done_[recv.meta.app_id].size();
     for (size_t customer_id = 0; customer_id < size; customer_id++) {

--- a/src/postoffice.cc
+++ b/src/postoffice.cc
@@ -42,9 +42,9 @@ void Postoffice::Init(ps::Node::Role role) {
   initialized_ = true;
 }
 
-Postoffice::Postoffice(int group_offset) {
+Postoffice::Postoffice(int instance_offset) {
   env_ref_ = Environment::_GetSharedRef();
-  group_offset_ = group_offset;
+  instance_offset_ = instance_offset;
 }
 
 void Postoffice::InitEnvironment() {

--- a/src/ucx_van.h
+++ b/src/ucx_van.h
@@ -924,7 +924,7 @@ class UCXVan : public Van {
     // Create separate UCX context for every device. If device is GPU, set the
     // corresponding cuda device before UCX context creation. This way UCX will
     // automatically select the most optimal NICs for using with this device.
-    CHECK(devs.size() == node.num_ports)
+    CHECK(static_cast<int>(devs.size()) == node.num_ports)
       << "num_cpu_dev + num_gpu_dev != num_ports";
     for (int i = 0; i < node.num_ports; ++i) {
       node.dev_types[i] = devs[i].first;

--- a/src/van.cc
+++ b/src/van.cc
@@ -637,7 +637,7 @@ int Van::Send(Message &msg) {
   CHECK_NE(send_bytes, -1) << this->GetType() << " sent -1 bytes";
   send_bytes_ += send_bytes;
   if (resender_) resender_->AddOutgoing(msg);
-  PS_VLOG(2) << this->GetType() << "\tsent: " << msg.DebugString();
+  PS_VLOG(2) << this->GetType() << " " << my_node_.id << "\tsent: " << msg.DebugString();
   return send_bytes;
 }
 
@@ -660,7 +660,7 @@ void Van::Receiving() {
 
     CHECK_NE(recv_bytes, -1);
     recv_bytes_ += recv_bytes;
-    PS_VLOG(2) << this->GetType() << "\treceived: " << msg.DebugString();
+    PS_VLOG(2) << this->GetType() << " " << my_node_.id << "\treceived: " << msg.DebugString();
     // duplicated message
     if (resender_ && resender_->AddIncomming(msg)) continue;
 

--- a/src/van.cc
+++ b/src/van.cc
@@ -113,7 +113,8 @@ void Van::ProcessTerminateCommand() {
 void Van::ProcessAddNodeCommandAtScheduler(Message *msg, Meta *nodes, Meta *recovery_nodes) {
   recovery_nodes->control.cmd = Control::ADD_NODE;
   time_t t = time(NULL);
-  size_t num_nodes = postoffice_->num_servers() + postoffice_->num_workers();
+  // consider all worker and server instances
+  size_t num_nodes = postoffice_->num_server_instances() + postoffice_->num_worker_instances();
   if (nodes->control.node.size() == num_nodes) {
     bool mixed_mode = 
         getenv("BYTEPS_ENABLE_MIXED_MODE") 
@@ -211,13 +212,13 @@ void Van::ProcessAddNodeCommandAtScheduler(Message *msg, Meta *nodes, Meta *reco
       }
 
       // check continousity
-      int num_servers = Postoffice::Get()->num_servers();
+      int num_servers = Postoffice::Get()->num_server_instances();
       for (int i = 0; i < num_servers; ++i) {
         CHECK(server_ranks.find(i) != server_ranks.end()) << i;
       }
       CHECK(server_ranks.size() == (size_t) num_servers);
 
-      int num_workers = Postoffice::Get()->num_workers();
+      int num_workers = Postoffice::Get()->num_worker_instances();
       for (int i = 0; i < num_workers; ++i) {
         CHECK(worker_ranks.find(i) != worker_ranks.end()) << i;
       }
@@ -284,14 +285,14 @@ void Van::ProcessAddNodeCommandAtScheduler(Message *msg, Meta *nodes, Meta *reco
       Send(back);
     }
   } else {
-    PS_VLOG(1) << "AddNode: " << nodes->control.node.size() << " / " << num_nodes;
+    PS_VLOG(1) << "AddNode: " << nodes->control.node.size() << "/" << num_nodes + 1;
   }
 }
 
 void Van::UpdateLocalID(Message* msg, std::unordered_set<int>* deadnodes_set,
                         Meta* nodes, Meta* recovery_nodes) {
   auto& ctrl = msg->meta.control;
-  size_t num_nodes = postoffice_->num_servers() + postoffice_->num_workers();
+  size_t num_nodes = postoffice_->num_server_instances() + postoffice_->num_worker_instances();
   // assign an id
   if (msg->meta.sender == Meta::kEmpty) {
     CHECK(is_scheduler_);
@@ -325,12 +326,6 @@ void Van::UpdateLocalID(Message* msg, std::unordered_set<int>* deadnodes_set,
     if (my_node_.hostname == node.hostname && my_node_.port == node.port) {
       if (getenv("DMLC_RANK") == nullptr || my_node_.id == Meta::kEmpty) {
         SetNode(node);
-        std::string rank = std::to_string(Postoffice::IDtoRank(node.id));
-#ifdef _MSC_VER
-        _putenv_s("DMLC_RANK", rank.c_str());
-#else
-        setenv("DMLC_RANK", rank.c_str(), true);
-#endif
       }
     }
   }
@@ -353,7 +348,7 @@ void Van::ProcessHearbeat(Message *msg) {
   }
 }
 
-void Van::ProcessBarrierCommand(Message *msg) {
+void Van::ProcessInstanceBarrierCommand(Message *msg) {
   auto &ctrl = msg->meta.control;
   if (msg->meta.request) {
     if (barrier_count_.empty()) {
@@ -368,7 +363,7 @@ void Van::ProcessBarrierCommand(Message *msg) {
       res.meta.request = false;
       res.meta.app_id = msg->meta.app_id;
       res.meta.customer_id = msg->meta.customer_id;
-      res.meta.control.cmd = Control::BARRIER;
+      res.meta.control.cmd = Control::INSTANCE_BARRIER;
       for (int r : postoffice_->GetNodeIDs(group)) {
         int recver_id = r;
         if (shared_node_mapping_.find(r) == shared_node_mapping_.end()) {
@@ -377,6 +372,54 @@ void Van::ProcessBarrierCommand(Message *msg) {
           CHECK_GT(Send(res), 0);
         }
       }
+    }
+  } else {
+    postoffice_->Manage(*msg);
+  }
+}
+
+// process the (group) barrier command
+void Van::ProcessBarrierCommand(Message *msg) {
+  // For group-level barrier, we only respond to the requesters
+  auto &ctrl = msg->meta.control;
+  if (msg->meta.request) {
+    int node_group = ctrl.barrier_group;
+    group_barrier_requests_[node_group].push_back(msg->meta.sender);
+    PS_VLOG(1) << "Barrier count for " << node_group << " : "
+               << group_barrier_requests_[node_group].size();
+
+    // Note: special handling for the scheduler thread,
+    // since the scheduler always has just one instance,
+    // while the worker/server may have multiple instances
+    int group_size = postoffice_->group_size();
+    int num_instances = static_cast<int>(postoffice_->GetNodeIDs(node_group).size());
+    size_t num_expected_requests;
+    if (node_group == kScheduler) {
+      // scheduler only
+      num_expected_requests = 1;
+    } else if (node_group & kScheduler) {
+      // scheduler, workers and/or servers
+      num_expected_requests = (num_instances - 1) / group_size + 1;
+    } else {
+      num_expected_requests = num_instances / group_size;
+    }
+    group_barrier_requests_[node_group].push_back(msg->meta.sender);
+    if (group_barrier_requests_[node_group].size() == num_expected_requests) {
+      Message res;
+      res.meta.request = false;
+      res.meta.app_id = msg->meta.app_id;
+      res.meta.customer_id = msg->meta.customer_id;
+      res.meta.control.cmd = Control::BARRIER;
+      // response to the requesters
+      for (int r : group_barrier_requests_[node_group]) {
+        int recver_id = r;
+        if (shared_node_mapping_.find(r) == shared_node_mapping_.end()) {
+          res.meta.recver = recver_id;
+          res.meta.timestamp = timestamp_++;
+          CHECK_GT(Send(res), 0);
+        }
+      }
+      group_barrier_requests_[node_group].clear();
     }
   } else {
     postoffice_->Manage(*msg);
@@ -525,7 +568,7 @@ void Van::Start(int customer_id, bool standalone) {
     // let the scheduler know myself
     Message msg;
     Node customer_specific_node = my_node_;
-    customer_specific_node.aux_id = Postoffice::Get()->preferred_rank();
+    customer_specific_node.aux_id = postoffice_->preferred_rank();
     customer_specific_node.customer_id = customer_id;
     msg.meta.recver = kScheduler;
     msg.meta.control.cmd = Control::ADD_NODE;
@@ -631,6 +674,8 @@ void Van::Receiving() {
         ProcessAddNodeCommand(&msg, &nodes, &recovery_nodes);
       } else if (ctrl.cmd == Control::BARRIER) {
         ProcessBarrierCommand(&msg);
+      } else if (ctrl.cmd == Control::INSTANCE_BARRIER) {
+        ProcessInstanceBarrierCommand(&msg);
       } else if (ctrl.cmd == Control::HEARTBEAT) {
         ProcessHearbeat(&msg);
       } else {
@@ -687,7 +732,7 @@ void Van::PackMeta(const Meta &meta, char **meta_buf, int *buf_size) {
   auto ctrl = &(raw->control);
   if (!meta.control.empty()) {
     ctrl->cmd = meta.control.cmd;
-    if (meta.control.cmd == Control::BARRIER) {
+    if (meta.control.cmd == Control::BARRIER || meta.control.cmd == Control::INSTANCE_BARRIER) {
       ctrl->barrier_group = meta.control.barrier_group;
     } else if (meta.control.cmd == Control::ACK) {
       ctrl->msg_sig = meta.control.msg_sig;

--- a/test.sh
+++ b/test.sh
@@ -52,7 +52,9 @@ export SKIP_DEV_ID_CHECK=${SKIP_DEV_ID_CHECK:-1}
 # export UCX_IB_GPU_DIRECT_RDMA=no
 
 export BYTEPS_ENABLE_IPC=0
-export BENCHMARK_NTHREAD=${BENCHMARK_NTHREAD:-1}
+export BENCHMARK_NTHREAD=${BENCHMARK_NTHREAD:=$DMLC_GROUP_SIZE}
+export GDB=" gdb -ex run --args "
+export GDB=" "
 
 if [ $1 == "local" ] # no other args
 then
@@ -62,14 +64,14 @@ then
     export UCX_RDMA_CM_SOURCE_ADDRESS=${NODE_ONE_IP}
 
     DMLC_ROLE=scheduler $BINARY $ARGS &
-    DMLC_ROLE=server $BINARY $ARGS
+    DMLC_ROLE=server $GDB $BINARY $ARGS
 elif [ $1 == "remote" ]
 then
     echo "This is the remote node."
     export DMLC_NODE_HOST=${NODE_TWO_IP}
     export UCX_RDMA_CM_SOURCE_ADDRESS=${NODE_TWO_IP}
 
-    DMLC_ROLE=worker $BINARY $ARGS
+    DMLC_ROLE=worker $GDB $BINARY $ARGS
 else
     echo "Please specify either local or remote."
 fi

--- a/test.sh
+++ b/test.sh
@@ -26,6 +26,8 @@ export UCX_MAX_RNDV_RAILS=${UCX_MAX_RNDV_RAILS:-2}
 export DMLC_ENABLE_RDMA=${DMLC_ENABLE_RDMA:-1}        # enable rdma
 export DMLC_ENABLE_UCX=${DMLC_ENABLE_UCX:-1}          # enable ucx
 export PS_VERBOSE=${PS_VERBOSE:-1}
+export DMLC_RANK=${DMLC_RANK:=0}
+export DMLC_GROUP_SIZE=${DMLC_GROUP_SIZE:=1}
 
 # export UCX_MEMTYPE_CACHE=n
 # export UCX_RNDV_SCHEME=put_zcopy

--- a/tests/test_benchmark.cc
+++ b/tests/test_benchmark.cc
@@ -386,9 +386,11 @@ void push_pull(KVWorker<char>* kv,
     if (cnt % log_duration != 0) continue;
 
     end = std::chrono::high_resolution_clock::now();
+    auto latency = (end - start).count();
+
     LL << "[" << tid << "]\tApplication goodput: "
-        << 8.0 * len * sizeof(char) * total_key_num * cnt / (end - start).count() 
-        << " Gbps";
+        << 8.0 * len * sizeof(char) * total_key_num * cnt / latency
+        << " Gbps.\tAvg latency = " << latency / cnt / total_key_num / 1000.0 << " ns per key";
     cnt = 0;
     start = std::chrono::high_resolution_clock::now();
   }

--- a/tests/test_benchmark.cc
+++ b/tests/test_benchmark.cc
@@ -31,7 +31,7 @@ enum MODE {
 std::unordered_map<uint64_t, KVPairs<char> > mem_map;
 
 // A map for the registered buffers
-std::unordered_map<int, std::unordered_map<ps::Key, SArray<char>>> registered_buffs;
+std::unordered_map<int64_t, std::unordered_map<ps::Key, SArray<char>>> registered_buffs;
 
 bool debug_mode_ = false;
 int num_ports = 1;
@@ -168,9 +168,11 @@ void EmptyHandler(const KVMeta &req_meta, const KVPairs<Val> &req_data, KVServer
     }
     if (enable_recv_buffer) {
       int worker_id = req_meta.sender;
-      CHECK(registered_buffs.find(worker_id) != registered_buffs.end())
-        << worker_id;
-      auto& buffs = registered_buffs[worker_id];
+      int64_t pair_id = server->instance_idx_;
+      pair_id = (pair_id << 32) + worker_id;
+      CHECK(registered_buffs.find(pair_id) != registered_buffs.end())
+        << worker_id << " " << server->instance_idx_ << " " << pair_id;
+      auto& buffs = registered_buffs[pair_id];
       CHECK(buffs.find(key_decoded) != buffs.end()) << key_decoded;
       auto registered = buffs[key_decoded].data();
       CHECK(registered == recved) << (long long) registered << " v.s. "
@@ -263,46 +265,54 @@ void GenerateLens(int total_key_num, int len, std::vector<SArray<int>>* server_l
 }
 
 
-void StartServer(int argc, char *argv[]) {
+void StartServer(int argc, char *argv[], int group_size) {
   if (!IsServer()) return;
   debug_mode_ = Environment::Get()->find("DEBUG_MODE") ? true : false;
 
-  auto server = new KVServer<char>(0);
-  server->set_request_handle(EmptyHandler<char>);
-  RegisterExitCallback([server]() { delete server; });
+  std::vector<KVServer<char>*> servers;
+  for (int i = 0; i < group_size; ++i) {
+    auto server = new KVServer<char>(0, false, i);
+    server->set_request_handle(EmptyHandler<char>);
+    servers.push_back(server);
+  }
 
   if (!enable_recv_buffer) return;
   int num_workers = Postoffice::Get()->num_workers();
   int num_servers = Postoffice::Get()->num_servers();
   auto my_rank = ps::Postoffice::Get()->my_rank();
   LOG(INFO) << "Registering buffers for server rank=" << my_rank
-    << ", num_servers=" << num_servers;
-  auto v = Environment::Get()->find("NUM_KEY_PER_SERVER");  
+            << ", num_servers=" << num_servers;
+  auto v = Environment::Get()->find("NUM_KEY_PER_SERVER");
   const int how_many_key_per_server = v ? atoi(v) : 40;
   const int total_key_num = num_servers * how_many_key_per_server;
   int len = (argc > 1) ? atoi(argv[1]) : 1024000;
+  // We generate different val buffs for each server instance to avoid conflicts
+  for (int instance_idx = 0; instance_idx < group_size; ++instance_idx) {
+    auto server = servers[instance_idx];
+    for (int worker_rank = 0; worker_rank < num_workers; worker_rank++) {
+      std::vector<SArray<char>> server_vals;
+      std::vector<SArray<Key>> server_keys;
+      std::vector<SArray<int>> server_lens;
+      GenerateVals(total_key_num, worker_rank, len, num_ports, &server_vals);
+      GenerateKeys(total_key_num, &server_keys);
+      GenerateLens(total_key_num, len, &server_lens);
+      for (int key = 0; key < total_key_num; ++key) {
+        if (my_rank == (key % num_servers)) {
+          server->RegisterRecvBufferWithRank(worker_rank, server_keys[key],
+                                             server_vals[key], server_lens[key]);
+          int64_t pair_id = instance_idx;
+          int worker_id = ps::Postoffice::Get()->WorkerRankToID(worker_rank);
+          pair_id = (pair_id << 32) + worker_id;
+          registered_buffs[pair_id][key] = server_vals[key];
 
-  for (int worker_rank = 0; worker_rank < num_workers; worker_rank++) {
-    std::vector<SArray<char>> server_vals;
-    std::vector<SArray<Key>> server_keys;
-    std::vector<SArray<int>> server_lens;
-    GenerateVals(total_key_num, worker_rank, len, num_ports, &server_vals);
-    GenerateKeys(total_key_num, &server_keys);
-    GenerateLens(total_key_num, len, &server_lens);
-    for (int key = 0; key < total_key_num; ++key) {
-      if (my_rank == (key % num_servers)) {
-        int worker_id = ps::Postoffice::Get()->WorkerRankToID(worker_rank);
-        server->RegisterRecvBuffer(worker_id, server_keys[key], server_vals[key],
-                                   server_lens[key]);
-        registered_buffs[worker_id][key] = server_vals[key];
+          mem_map[key].keys = server_keys[key];
+          mem_map[key].vals = server_vals[key];
+          mem_map[key].lens = server_lens[key];
 
-        mem_map[key].keys = server_keys[key];
-        mem_map[key].vals = server_vals[key];
-        mem_map[key].lens = server_lens[key];
-
-        LOG(INFO) << "Registered buffer for worker_rank=" << worker_rank
-          << " worker_id " << worker_id << " key " << key << " ptr "
-          << (long long) server_vals[key].data();
+          LOG(INFO) << "Server instance " << instance_idx << " registered buffer for worker_rank="
+                    << worker_rank << " key " << key << " ptr "
+                    << (long long) server_vals[key].data();
+        }
       }
     }
   }
@@ -413,6 +423,7 @@ void RunWorker(int argc, char *argv[], KVWorker<char>* kv, int tid) {
   // place a barrier to make sure the server has all the buffers registered.
   if (enable_recv_buffer) {
     ps::Postoffice::Get()->Barrier(0, kWorkerGroup + kServerGroup);
+    LOG(INFO) << "Server recv buff registration is DONE.";
   }
 
   // init push, do not count this into time cost


### PR DESCRIPTION
This PR introduces multiple postoffice instances in a process, configured by environment variable `DMLC_GROUP_SIZE`. 
Ps-lite users can create `DMLC_GROUP_SIZE` number of KVWorkers or KVServers in the code within the process. Using multiple threads to send data concurrently with this feature may help improve the throughput when there are lots of small messages to sent.

For example, in a 1w1s setting, with DMLC_GROUP_SIZE=1, we have:
- DMLC_NUM_WORKER=1, DMLC_NUM_SERVER=1
- 1 postoffice/van for the scheduler
- 1 postoffice/van for the worker 0
- 1 postoffice/van for the server 0

To increase the number of worker/server instances within the process, you can set DMLC_GROUP_SIZE=2:
- DMLC_NUM_WORKER=1, DMLC_NUM_SERVER=1
- 1 postoffice/van for the scheduler
- 2 postoffice/van for the worker 0
- 2 postoffice/van for the server 0

Users are expected to encode the key as usual based on DMLC_NUM_WORKER (which is not changed). 

On the 2-node V100 testbed with 100 Gb/s NIC, doing PUSH_ONLY with 400 25KB messages (1w1s), with UCXVan:
- 29 Gb/s with `DMLC_GROUP_SIZE`=1
- 53 Gb/s with `DMLC_GROUP_SIZE`=2

Finally, this PR also introduces `RegisterRecvBufferWithRank` API where the first argument is `worker_rank` instead of `worker_id`. Using `worker_rank` is more user-friendly for the application layer above ps-lite. 
